### PR TITLE
feat: improve color system and layout design

### DIFF
--- a/src/components/AboutMeContent/AboutMeContent.jsx
+++ b/src/components/AboutMeContent/AboutMeContent.jsx
@@ -22,7 +22,8 @@ const AboutMeContent = () => {
         variant="h2"
         sx={{
           fontWeight: 700,
-          background: (theme) => `linear-gradient(45deg, ${theme.palette.primary.main} 30%, ${theme.palette.secondary.main} 90%)`,
+          background: (theme) =>
+            `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.light} 50%, ${theme.palette.secondary.main} 100%)`,
           WebkitBackgroundClip: "text",
           WebkitTextFillColor: "transparent",
         }}
@@ -103,14 +104,27 @@ const AboutMeContent = () => {
             borderRadius: 2,
             textTransform: "none",
             fontSize: "1.1rem",
-            background: (theme) => `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
-            color: "white",
-            boxShadow: (theme) => `0 4px 12px ${alpha(theme.palette.primary.main, 0.3)}`,
+            background: (theme) =>
+              theme.palette.mode === "dark"
+                ? `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`
+                : `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 100%)`,
+            color: (theme) => (theme.palette.mode === "dark" ? "#0A0F0D" : "#FFFFFF"),
+            fontWeight: 600,
+            boxShadow: (theme) =>
+              theme.palette.mode === "dark"
+                ? `0 4px 20px ${alpha(theme.palette.primary.main, 0.35)}`
+                : `0 4px 16px ${alpha(theme.palette.primary.dark, 0.25)}`,
             transition: "all 0.3s ease-in-out",
             "&:hover": {
-              background: (theme) => `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 100%)`,
-              boxShadow: (theme) => `0 6px 16px ${alpha(theme.palette.primary.main, 0.4)}`,
-              transform: "translateY(-1px)",
+              background: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`
+                  : `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
+              boxShadow: (theme) =>
+                theme.palette.mode === "dark"
+                  ? `0 6px 24px ${alpha(theme.palette.primary.main, 0.45)}`
+                  : `0 6px 20px ${alpha(theme.palette.primary.dark, 0.35)}`,
+              transform: "translateY(-2px)",
             },
           }}
         >

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -33,6 +33,7 @@ const StyledAppBar = styled(AppBar)(({ theme }) => ({
 
 const StyledTerminalIcon = styled(TerminalIcon)(({ theme }) => ({
   transition: "all 0.3s ease-in-out",
+  color: theme.palette.text.primary,
   "&:hover": {
     transform: "scale(1.1)",
     color: theme.palette.primary.main,
@@ -71,11 +72,11 @@ const Header = () => {
               href="/cmd"
               edge="start"
               size="large"
-              color="inherit"
               aria-label="terminal-icon"
               sx={{
                 "&:hover": {
-                  backgroundColor: alpha("#fff", 0.1),
+                  backgroundColor: (theme) =>
+                    theme.palette.mode === "dark" ? alpha("#fff", 0.1) : alpha("#000", 0.1),
                 },
               }}
             >
@@ -147,12 +148,13 @@ const Header = () => {
             <IconButton
               onClick={toggleTheme}
               size={isMobile ? "small" : "medium"}
-              color="inherit"
               aria-label="theme-toggle"
               sx={{
                 ml: 0.5,
+                color: (theme) => theme.palette.text.primary,
                 "&:hover": {
-                  backgroundColor: alpha("#fff", 0.1),
+                  backgroundColor: (theme) =>
+                    theme.palette.mode === "dark" ? alpha("#fff", 0.1) : alpha("#000", 0.1),
                 },
               }}
             >

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -106,18 +106,21 @@ const Header = () => {
                   sx={{
                     fontWeight: 600,
                     letterSpacing: "-0.02em",
-                    background: "linear-gradient(45deg, #fff 30%, #e0e0e0 90%)",
+                    background: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "linear-gradient(45deg, #E8F5E9 30%, #A5C4AC 90%)"
+                        : "linear-gradient(45deg, #1A2E1F 30%, #4A6B52 90%)",
                     WebkitBackgroundClip: "text",
                     WebkitTextFillColor: "transparent",
                   }}
                 />
                 <BlinkingTypography
                   variant="h4"
-                  color="inherit"
                   sx={{
                     opacity: 0.7,
                     fontWeight: 300,
                     fontSize: isMobile ? "1.25rem" : "1.5rem",
+                    color: (theme) => theme.palette.text.primary,
                   }}
                 >
                   |
@@ -125,7 +128,6 @@ const Header = () => {
               </Box>
               <Typography
                 variant="h5"
-                color="inherit"
                 sx={{
                   lineHeight: 1,
                   opacity: 0.8,
@@ -133,6 +135,7 @@ const Header = () => {
                   letterSpacing: "-0.01em",
                   fontSize: isMobile ? "1rem" : "1.1rem",
                   mt: 0,
+                  color: (theme) => theme.palette.text.primary,
                 }}
               >
                 Nice to meet you.

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -39,7 +39,12 @@ const LanguageToggle = () => {
   if (isMobile) {
     return (
       <>
-        <IconButton onClick={handleClick} color="inherit" aria-label="language-toggle" size="small">
+        <IconButton
+          onClick={handleClick}
+          aria-label="language-toggle"
+          size="small"
+          sx={{ color: (theme) => theme.palette.text.primary }}
+        >
           <LanguageIcon sx={{ fontSize: "1.9rem" }} />
         </IconButton>
         <Menu

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -74,10 +74,40 @@ const LanguageToggle = () => {
 
   return (
     <ButtonGroup variant="contained" size="small">
-      <Button onClick={toggleLanguage} color={language === "en" ? "primary" : "inherit"} startIcon={<FlagIcon src="/usa.svg" alt="USA Flag" />}>
+      <Button
+        onClick={toggleLanguage}
+        color={language === "en" ? "primary" : "inherit"}
+        startIcon={<FlagIcon src="/usa.svg" alt="USA Flag" />}
+        sx={{
+          ...(language !== "en" && {
+            backgroundColor: (theme) =>
+              theme.palette.mode === "dark" ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)",
+            color: (theme) => theme.palette.text.primary,
+            "&:hover": {
+              backgroundColor: (theme) =>
+                theme.palette.mode === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)",
+            },
+          }),
+        }}
+      >
         {t("english")}
       </Button>
-      <Button onClick={toggleLanguage} color={language === "pt" ? "primary" : "inherit"} startIcon={<FlagIcon src="/br.svg" alt="Brazil Flag" />}>
+      <Button
+        onClick={toggleLanguage}
+        color={language === "pt" ? "primary" : "inherit"}
+        startIcon={<FlagIcon src="/br.svg" alt="Brazil Flag" />}
+        sx={{
+          ...(language !== "pt" && {
+            backgroundColor: (theme) =>
+              theme.palette.mode === "dark" ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)",
+            color: (theme) => theme.palette.text.primary,
+            "&:hover": {
+              backgroundColor: (theme) =>
+                theme.palette.mode === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)",
+            },
+          }),
+        }}
+      >
         {t("portuguese")}
       </Button>
     </ButtonGroup>

--- a/src/components/MainCard/MainCard.jsx
+++ b/src/components/MainCard/MainCard.jsx
@@ -22,12 +22,25 @@ const FlippingCard = styled(Card, {
   shouldForwardProp: (prop) => prop !== "flip",
 })(({ theme, flip }) => ({
   transform: !flip ? "scaleX(1)" : "scaleX(-1)",
-  transition: theme.transitions.create(["transform"], {
+  transition: theme.transitions.create(["transform", "box-shadow"], {
     duration: theme.transitions.duration.shortest,
   }),
-  background: alpha(theme.palette.background.paper, 0.8),
-  backdropFilter: "blur(10px)",
-  border: `1px solid ${alpha(theme.palette.divider, 0.1)}`,
+  background:
+    theme.palette.mode === "dark"
+      ? alpha(theme.palette.background.paper, 0.85)
+      : alpha(theme.palette.background.paper, 0.9),
+  backdropFilter: "blur(12px)",
+  border: `1px solid ${theme.palette.custom?.cardBorder || alpha(theme.palette.primary.main, 0.15)}`,
+  boxShadow:
+    theme.palette.mode === "dark"
+      ? `0 4px 24px rgba(0, 0, 0, 0.3), inset 0 1px 0 ${alpha(theme.palette.primary.main, 0.1)}`
+      : `0 4px 20px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.8)`,
+  "&:hover": {
+    boxShadow:
+      theme.palette.mode === "dark"
+        ? `0 8px 32px rgba(16, 185, 129, 0.2), 0 4px 16px rgba(0, 0, 0, 0.4)`
+        : `0 8px 28px rgba(5, 150, 105, 0.12), 0 4px 12px rgba(0, 0, 0, 0.06)`,
+  },
 }));
 
 const MainCard = ({ title, headerIcon, flipEnabled, backContent = "", frontContent = "" }) => {

--- a/src/components/TypewriterText/TypewriterText.jsx
+++ b/src/components/TypewriterText/TypewriterText.jsx
@@ -2,11 +2,11 @@ import { Typography } from "@mui/material";
 
 import { useTypewriter } from "../../hooks";
 
-const TypewriterText = ({ text, speed, variant = "body2", color = "inherit", fontSize = "1rem" }) => {
+const TypewriterText = ({ text, speed, variant = "body2", color = "inherit", fontSize = "1rem", sx }) => {
   const displayText = useTypewriter(text, speed);
 
   return (
-    <Typography variant={variant} color={color} fontSize={fontSize}>
+    <Typography variant={variant} color={color} fontSize={fontSize} sx={sx}>
       {displayText}
     </Typography>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -15,7 +15,9 @@ const Home = () => {
         display: "flex",
         flexDirection: "column",
         background: (theme) =>
-          `linear-gradient(135deg, ${alpha(theme.palette.background.default, 0.95)} 0%, ${alpha(theme.palette.background.paper, 0.95)} 100%)`,
+          theme.palette.mode === "dark"
+            ? `linear-gradient(135deg, ${theme.palette.background.default} 0%, ${alpha(theme.palette.background.paper, 0.98)} 50%, ${theme.palette.background.default} 100%)`
+            : `linear-gradient(135deg, ${theme.palette.background.default} 0%, ${theme.palette.background.paper} 50%, ${alpha(theme.palette.primary.main, 0.03)} 100%)`,
       }}
     >
       <Box
@@ -46,11 +48,14 @@ const Home = () => {
                     "&::before": {
                       content: '""',
                       position: "absolute",
-                      top: -20,
-                      left: -20,
-                      right: -20,
-                      bottom: -20,
-                      background: (theme) => `radial-gradient(circle, ${alpha(theme.palette.primary.main, 0.1)} 0%, transparent 70%)`,
+                      top: -30,
+                      left: -30,
+                      right: -30,
+                      bottom: -30,
+                      background: (theme) =>
+                        theme.palette.mode === "dark"
+                          ? `radial-gradient(circle, ${alpha(theme.palette.primary.main, 0.15)} 0%, ${alpha(theme.palette.secondary.main, 0.05)} 50%, transparent 70%)`
+                          : `radial-gradient(circle, ${alpha(theme.palette.primary.main, 0.08)} 0%, ${alpha(theme.palette.secondary.main, 0.03)} 50%, transparent 70%)`,
                       zIndex: -1,
                       borderRadius: "50%",
                     },

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,28 +3,50 @@ import { createTheme } from "@mui/material/styles";
 export const getTheme = (mode) => {
   const isDark = mode === 'dark';
 
+  // Sophisticated color palette - softer, more eye-friendly greens
+  const colors = {
+    // Primary: Emerald green - softer than lime, maintains terminal aesthetic
+    primary: {
+      main: isDark ? '#10B981' : '#059669',      // Emerald 500/600
+      light: isDark ? '#34D399' : '#10B981',     // Emerald 400/500
+      dark: isDark ? '#059669' : '#047857',      // Emerald 600/700
+    },
+    // Secondary: Cyan/Teal - complements green better than magenta
+    secondary: {
+      main: isDark ? '#06B6D4' : '#0891B2',      // Cyan 500/600
+      light: isDark ? '#22D3EE' : '#06B6D4',     // Cyan 400/500
+      dark: isDark ? '#0891B2' : '#0E7490',      // Cyan 600/700
+    },
+    // Backgrounds with more depth
+    background: {
+      default: isDark ? '#0A0F0D' : '#F8FAF9',   // Very dark green-tint / Light mint-white
+      paper: isDark ? '#111916' : '#FFFFFF',     // Dark green-gray / Pure white
+      elevated: isDark ? '#1A2420' : '#F0F5F3',  // Slightly lighter / Soft mint
+    },
+    // Text colors with better contrast
+    text: {
+      primary: isDark ? '#E8F5E9' : '#1A2E1F',   // Light mint / Dark forest
+      secondary: isDark ? '#A5C4AC' : '#4A6B52', // Muted green / Medium forest
+    },
+  };
+
   return createTheme({
     palette: {
       mode,
-      primary: {
-        main: '#00ff00',
-        light: '#4cff4c',
-        dark: '#00cc00',
-      },
-      secondary: {
-        main: '#ff00ff',
-        light: '#ff4cff',
-        dark: '#cc00cc',
-      },
+      primary: colors.primary,
+      secondary: colors.secondary,
       background: {
-        default: isDark ? '#121212' : '#ffffff',
-        paper: isDark ? '#1e1e1e' : '#f5f5f5',
+        default: colors.background.default,
+        paper: colors.background.paper,
       },
-      text: {
-        primary: isDark ? '#ffffff' : '#000000',
-        secondary: isDark ? '#b3b3b3' : '#666666',
+      text: colors.text,
+      divider: isDark ? 'rgba(16, 185, 129, 0.15)' : 'rgba(5, 150, 105, 0.12)',
+      // Custom colors accessible via theme.palette
+      custom: {
+        elevated: colors.background.elevated,
+        glow: isDark ? 'rgba(16, 185, 129, 0.4)' : 'rgba(5, 150, 105, 0.2)',
+        cardBorder: isDark ? 'rgba(16, 185, 129, 0.2)' : 'rgba(5, 150, 105, 0.15)',
       },
-      divider: isDark ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 0, 0, 0.12)',
     },
     typography: {
       fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
@@ -64,13 +86,15 @@ export const getTheme = (mode) => {
     components: {
       MuiCard: {
         styleOverrides: {
-          root: {
+          root: ({ theme }) => ({
             borderRadius: 12,
             transition: 'all 0.3s ease-in-out',
             '&:hover': {
-              boxShadow: (theme) => `0 8px 24px ${theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.3)' : 'rgba(0, 0, 0, 0.1)'}`,
+              boxShadow: theme.palette.mode === 'dark'
+                ? `0 8px 32px rgba(16, 185, 129, 0.15), 0 4px 16px rgba(0, 0, 0, 0.3)`
+                : `0 8px 24px rgba(5, 150, 105, 0.1), 0 4px 12px rgba(0, 0, 0, 0.05)`,
             },
-          },
+          }),
         },
       },
       MuiButton: {


### PR DESCRIPTION
## Summary
- Replace harsh lime green (#00ff00) with softer emerald tones (#10B981)
- Replace magenta secondary color with complementary cyan (#06B6D4)
- Add green-tinted backgrounds for better visual depth in dark/light modes
- Fix header text visibility in light mode (was invisible white on light background)
- Fix language toggle inactive button contrast in light mode
- Enhance card styling with subtle borders and glow effects

## Color Palette Changes

| Element | Before | After |
|---------|--------|-------|
| Primary | `#00ff00` (harsh lime) | `#10B981` (emerald) |
| Secondary | `#ff00ff` (magenta) | `#06B6D4` (cyan) |
| Dark BG | `#121212` | `#0A0F0D` (green tint) |
| Light BG | `#ffffff` | `#F8FAF9` (mint tint) |

## Files Changed
- `src/theme.js` - New color palette
- `src/components/Header.jsx` - Theme-aware text colors
- `src/components/LanguageToggle.jsx` - Better inactive button contrast
- `src/components/TypewriterText/TypewriterText.jsx` - Added sx prop support
- `src/components/AboutMeContent/AboutMeContent.jsx` - Updated gradients
- `src/components/MainCard/MainCard.jsx` - Enhanced card styling
- `src/pages/Home.jsx` - Updated background gradients

## Test plan
- [x] Verify light mode header text is visible
- [x] Verify language toggle buttons have proper contrast in both modes
- [x] Verify dark mode still looks good
- [x] Run `yarn lint` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)